### PR TITLE
Use Rails.backtrace_cleaner.clean

### DIFF
--- a/lib/capybara-rails/railtie.rb
+++ b/lib/capybara-rails/railtie.rb
@@ -22,7 +22,7 @@ module Capybara
         ExceptionNotifier.add_notifier :capybara_exceptions,
           ->(exception, options) {
             exception_logger.debug(exception.message)
-            cleaned_backtrace = ::Rails.backtrace_cleaner.filter exception.backtrace
+            cleaned_backtrace = ::Rails.backtrace_cleaner.clean(exception.backtrace)
             exception_logger.debug(cleaned_backtrace)
           }
 


### PR DESCRIPTION
The `filter` alias for `clean` was added in Rails 4.0.0.

Relevant commit: https://github.com/rails/rails/commit/d91bee80beae4e92b2b015599771310cebc3a143
