### PR TITLE
Remove a middleware deprecation message.

### DIFF
--- a/lib/capybara-rails/railtie.rb
+++ b/lib/capybara-rails/railtie.rb
@@ -26,7 +26,7 @@ module Capybara
             exception_logger.debug(cleaned_backtrace)
           }
 
-        app.middleware.use 'ExceptionNotification::Rack'
+        app.middleware.use ExceptionNotification::Rack
       end
     end
   end


### PR DESCRIPTION
```
DEPRECATION WARNING: Passing strings or symbols to the middleware builder is deprecated, please change
them to actual class references.  For example:

  ExceptionNotification::Rack => ExceptionNotification::Rack
```
